### PR TITLE
Updated Reference to point to Add-In lib with absolute path

### DIFF
--- a/src/VidyoIntegration/Addin/VidyoAddin/VidyoAddin.csproj
+++ b/src/VidyoIntegration/Addin/VidyoAddin/VidyoAddin.csproj
@@ -50,7 +50,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="ININ.InteractionClient.Addin">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Interactive Intelligence\ICUserApps\ININ.InteractionClient.Addin.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Interactive Intelligence\ICUserApps\ININ.InteractionClient.Addin.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="PresentationCore" />


### PR DESCRIPTION
Whereas the client is most always (99.99%) installed on the C: drive, the VidyoIntegration repo can be loaded at various depths or different drives on the developer's machine.

Until we have a common well-known place to hold these (git  submodule?), we might want to point to the Add-In library with a hard-coded path.
