### PR TITLE
Use the Vidyo Room URL when inviting other users

### DIFF
--- a/src/VidyoIntegration/Addin/VidyoAddin/ViewModel/VidyoPanelViewModel.cs
+++ b/src/VidyoIntegration/Addin/VidyoAddin/ViewModel/VidyoPanelViewModel.cs
@@ -796,7 +796,7 @@ namespace VidyoIntegration.VidyoAddin.ViewModel
                      * [2] = Join url (guest link)
                      */
                     SendCustomNotification(CustomMessageType.ApplicationRequest, interaction.TransferTarget.Entry.EntryId,
-                        JoinVidyoConferenceRequestEid, _session.UserId, message, "http://www.inin.com");
+                        JoinVidyoConferenceRequestEid, _session.UserId, message, interaction.VidyoRoomUrl);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
The previous code was simply sending the other user to www.inin.com instead of the Vidyo room.
