### PR TITLE
Removed useless XML attributes in the service wxs script

### DIFF
--- a/src/VidyoIntegration/Common/VidyoIntegrationWindowsServiceInstaller/Product.wxs
+++ b/src/VidyoIntegration/Common/VidyoIntegrationWindowsServiceInstaller/Product.wxs
@@ -44,53 +44,53 @@
   <Fragment>
     <ComponentGroup Id="ProductComponents">
       <Component Id="VidyoIntegrationService" Guid="2D254B9C-E688-442D-9571-7009478114B9" Directory="INSTALLLOCATION">
-        <File Id="ace_w32r_4_0.dll" Name="ace-w32r-4-0.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ace-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="core_events_w32r_4_0.dll" Name="core_events-w32r-4-0.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\core_events-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="i3core_w32r_4_0.dll" Name="i3core-w32r-4-0.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3core-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="i3eventlog_w32r_4_0.dll" Name="i3eventlog-w32r-4-0.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3eventlog-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="i3moduleregistry_w32.dll" Name="i3moduleregistry-w32.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3moduleregistry-w32.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="i3serialize_managed_a00r_4_0.dll" Name="i3serialize_managed-a00r-4-0.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3serialize_managed-a00r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="i3serialize_managed_a00r_4_0.pdb" Name="i3serialize_managed-a00r-4-0.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3serialize_managed-a00r-5-0.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="i3trace_w32r_4_0.dll" Name="i3trace-w32r-4-0.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3trace-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="i3trace_dotnet_tracing_w32r_4_0.dll" Name="i3trace_dotnet_tracing-w32r-4-0.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3trace_dotnet_tracing-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="i3trace_dotnet_tracing_w32r_4_0.pdb" Name="i3trace_dotnet_tracing-w32r-4-0.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3trace_dotnet_tracing-w32r-5-0.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="i3trace_dotnet_tracing_interop_w32r_4_0.dll" Name="i3trace_dotnet_tracing_interop-w32r-4-0.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3trace_dotnet_tracing_interop-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="ININ.Common.dll" Name="ININ.Common.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.Common.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="ININ.Common.pdb" Name="ININ.Common.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.Common.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="ININ.IceLib.dll" Name="ININ.IceLib.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.IceLib.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="ININ.IceLib.pdb" Name="ININ.IceLib.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.IceLib.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="ININ.IceLib.Interactions.dll" Name="ININ.IceLib.Interactions.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.IceLib.Interactions.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="ININ.IceLib.Interactions.pdb" Name="ININ.IceLib.Interactions.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.IceLib.Interactions.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="ININ.IceLib.People.dll" Name="ININ.IceLib.People.dll" Source="$(var.CoreServiceLib.TargetDir)\ININ.IceLib.People.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="ININ.IceLib.People.pdb" Name="ININ.IceLib.People.pdb" Source="$(var.CoreServiceLib.TargetDir)\ININ.IceLib.People.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="ININ.IceLib.Statistics.dll" Name="ININ.IceLib.Statistics.dll" Source="$(var.CoreServiceLib.TargetDir)\ININ.IceLib.Statistics.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="ININ.IceLib.Statistics.pdb" Name="ININ.IceLib.Statistics.pdb" Source="$(var.CoreServiceLib.TargetDir)\ININ.IceLib.Statistics.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="ININ.ThinBridge.dll" Name="ININ.ThinBridge.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.ThinBridge.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="ININ.ThinBridge.pdb" Name="ININ.ThinBridge.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.ThinBridge.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="ININ.ThinBridge.Types.dll" Name="ININ.ThinBridge.Types.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.ThinBridge.Types.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="ININ.ThinBridge.Types.pdb" Name="ININ.ThinBridge.Types.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.ThinBridge.Types.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="Nancy.dll" Name="Nancy.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\Nancy.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="Nancy.Hosting.Self.dll" Name="Nancy.Hosting.Self.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\Nancy.Hosting.Self.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="Nancy.Serialization.JsonNet.dll" Name="Nancy.Serialization.JsonNet.dll" Source="$(var.CoreServiceLib.TargetDir)\Nancy.Serialization.JsonNet.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="Newtonsoft.Json.dll" Name="Newtonsoft.Json.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\Newtonsoft.Json.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="openssl_w32r_4_0.dll" Name="openssl-w32r-4-0.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\openssl-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="RestSharp.dll" Name="RestSharp.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\RestSharp.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="stlport_w32r_4_0.dll" Name="stlport-w32r-4-0.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\stlport-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="VidyoIntegration.CicManagerLib.dll" Name="VidyoIntegration.CicManagerLib.dll" Source="$(var.CoreServiceLib.TargetDir)\VidyoIntegration.CicManagerLib.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="VidyoIntegration.CicManagerLib.pdb" Name="VidyoIntegration.CicManagerLib.pdb" Source="$(var.CoreServiceLib.TargetDir)\VidyoIntegration.CicManagerLib.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="VidyoIntegration.CommonLib.dll" Name="VidyoIntegration.CommonLib.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\VidyoIntegration.CommonLib.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="VidyoIntegration.CommonLib.pdb" Name="VidyoIntegration.CommonLib.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\VidyoIntegration.CommonLib.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="VidyoIntegration.ConversationManagerLib.dll" Name="VidyoIntegration.ConversationManagerLib.dll" Source="$(var.CoreServiceLib.TargetDir)\VidyoIntegration.ConversationManagerLib.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="VidyoIntegration.ConversationManagerLib.pdb" Name="VidyoIntegration.ConversationManagerLib.pdb" Source="$(var.CoreServiceLib.TargetDir)\VidyoIntegration.ConversationManagerLib.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="VidyoIntegration.CoreServiceLib.dll" Name="VidyoIntegration.CoreServiceLib.dll" Source="$(var.CoreServiceLib.TargetDir)\VidyoIntegration.CoreServiceLib.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="VidyoIntegration.CoreServiceLib.pdb" Name="VidyoIntegration.CoreServiceLib.pdb" Source="$(var.CoreServiceLib.TargetDir)\VidyoIntegration.CoreServiceLib.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="VidyoIntegration.TraceLib.dll" Name="VidyoIntegration.TraceLib.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\VidyoIntegration.TraceLib.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="VidyoIntegration.TraceLib.pdb" Name="VidyoIntegration.TraceLib.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\VidyoIntegration.TraceLib.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="VidyoIntegration.VidyoService.dll" Name="VidyoIntegration.VidyoService.dll" Source="$(var.VidyoService.TargetDir)\VidyoIntegration.VidyoService.dll" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="VidyoIntegration.VidyoService.pdb" Name="VidyoIntegration.VidyoService.pdb" Source="$(var.VidyoService.TargetDir)\VidyoIntegration.VidyoService.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="VidyoIntegrationWindowsService.exe" Name="VidyoIntegrationWindowsService.exe" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\VidyoIntegrationWindowsService.exe" Vital="yes" KeyPath="yes" DiskId="1"/>
-        <File Id="VidyoIntegrationWindowsService.exe.config" Name="VidyoIntegrationWindowsService.exe.config" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\VidyoIntegrationWindowsService.exe.config" Vital="yes" KeyPath="no" DiskId="1"/>
-        <File Id="VidyoIntegrationWindowsService.pdb" Name="VidyoIntegrationWindowsService.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\VidyoIntegrationWindowsService.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ace.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ace-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="core_events.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\core_events-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="i3core.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3core-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="i3eventlog.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3eventlog-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="i3moduleregistry.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3moduleregistry-w32.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="i3serialize_managed.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3serialize_managed-a00r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="i3serialize_managed.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3serialize_managed-a00r-5-0.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="i3trace.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3trace-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="i3trace_dotnet_tracing.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3trace_dotnet_tracing-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="i3trace_dotnet_tracing.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3trace_dotnet_tracing-w32r-5-0.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="i3trace_dotnet_tracing_interop.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\i3trace_dotnet_tracing_interop-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ININ.Common.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.Common.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ININ.Common.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.Common.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ININ.IceLib.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.IceLib.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ININ.IceLib.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.IceLib.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ININ.IceLib.Interactions.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.IceLib.Interactions.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ININ.IceLib.Interactions.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.IceLib.Interactions.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ININ.IceLib.People.dll" Source="$(var.CoreServiceLib.TargetDir)\ININ.IceLib.People.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ININ.IceLib.People.pdb" Source="$(var.CoreServiceLib.TargetDir)\ININ.IceLib.People.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ININ.IceLib.Statistics.dll" Source="$(var.CoreServiceLib.TargetDir)\ININ.IceLib.Statistics.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ININ.IceLib.Statistics.pdb" Source="$(var.CoreServiceLib.TargetDir)\ININ.IceLib.Statistics.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ININ.ThinBridge.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.ThinBridge.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ININ.ThinBridge.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.ThinBridge.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ININ.ThinBridge.Types.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.ThinBridge.Types.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="ININ.ThinBridge.Types.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\ININ.ThinBridge.Types.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="Nancy.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\Nancy.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="Nancy.Hosting.Self.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\Nancy.Hosting.Self.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="Nancy.Serialization.JsonNet.dll" Source="$(var.CoreServiceLib.TargetDir)\Nancy.Serialization.JsonNet.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="Newtonsoft.Json.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\Newtonsoft.Json.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="openssl.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\openssl-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="RestSharp.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\RestSharp.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="stlport.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\stlport-w32r-5-0.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="VidyoIntegration.CicManagerLib.dll" Source="$(var.CoreServiceLib.TargetDir)\VidyoIntegration.CicManagerLib.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="VidyoIntegration.CicManagerLib.pdb" Source="$(var.CoreServiceLib.TargetDir)\VidyoIntegration.CicManagerLib.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="VidyoIntegration.CommonLib.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\VidyoIntegration.CommonLib.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="VidyoIntegration.CommonLib.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\VidyoIntegration.CommonLib.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="VidyoIntegration.ConversationManagerLib.dll" Source="$(var.CoreServiceLib.TargetDir)\VidyoIntegration.ConversationManagerLib.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="VidyoIntegration.ConversationManagerLib.pdb" Source="$(var.CoreServiceLib.TargetDir)\VidyoIntegration.ConversationManagerLib.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="VidyoIntegration.CoreServiceLib.dll" Source="$(var.CoreServiceLib.TargetDir)\VidyoIntegration.CoreServiceLib.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="VidyoIntegration.CoreServiceLib.pdb" Source="$(var.CoreServiceLib.TargetDir)\VidyoIntegration.CoreServiceLib.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="VidyoIntegration.TraceLib.dll" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\VidyoIntegration.TraceLib.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="VidyoIntegration.TraceLib.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\VidyoIntegration.TraceLib.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="VidyoIntegration.VidyoService.dll" Source="$(var.VidyoService.TargetDir)\VidyoIntegration.VidyoService.dll" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="VidyoIntegration.VidyoService.pdb" Source="$(var.VidyoService.TargetDir)\VidyoIntegration.VidyoService.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="VidyoIntegrationWindowsService.exe" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\VidyoIntegrationWindowsService.exe" Vital="yes" KeyPath="yes" DiskId="1"/>
+        <File Id="VidyoIntegrationWindowsService.exe.config" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\VidyoIntegrationWindowsService.exe.config" Vital="yes" KeyPath="no" DiskId="1"/>
+        <File Id="VidyoIntegrationWindowsService.pdb" Source="$(var.VidyoIntegrationWindowsService.TargetDir)\VidyoIntegrationWindowsService.pdb" Vital="yes" KeyPath="no" DiskId="1"/>
 
         <!-- Install service -->
         <ServiceInstall


### PR DESCRIPTION
Basically, the Name of a File element in the wxs can be deducted from the Source attribute, it is therefore redundant.
I also removed the trace/ace/stl/etc version numbers from the Id attribute as they don't help much and make it more prone to errors when we update the Icelib version (I am also writing a script for that).
